### PR TITLE
Reword section on boolean operation, and fix answer

### DIFF
--- a/notebooks/1. Beginning with Python.ipynb
+++ b/notebooks/1. Beginning with Python.ipynb
@@ -1194,7 +1194,7 @@
     "collapsed": false
    },
    "source": [
-    "**We can use the *and* ( & ) and *or* ( | ) operators with booleans.**\n",
+    "**We can use the boolean `and` and boolean `or` operators with booleans.**\n",
     ">Check if the length of your name is greater than 5 and the lenght of your mentor's name is less than 7."
    ]
   },

--- a/solutions/01_22.py
+++ b/solutions/01_22.py
@@ -1,1 +1,1 @@
-(len('Sandrine') > 5) & (len('Cheuk') <7)
+(len("Sandrine") > 5) and (len("Cheuk") < 7)


### PR DESCRIPTION
The earlier wording refered to the boolean AND and OR operators as `&`
and `|`.  However in Python, they refer to bitwise AND and OR
operators respectively.  The corresponding solution also uses these
bitwise operators.

Note, the expression does evaluate to the correct answer, but it is by
accident.  This won't be surprising when both operands are booleans,
but the result will be surprising to beginners if one of them happens
to be a different type.  Here's an example:

    >>> 5 & 7
    5
    >>> 5 and 7
    7

The first example is a bitwise AND of 0b101 with 0b111, evaluating to
0b101 which is 5 in decimal notation.  Whereas for the later both 5
and 7 evaluate as True, so Python returns the last value that
evaluates as True, which is 7.  I don't think introducing beginners to
bitwise operations was the intention of this example.